### PR TITLE
MM-2 Add Mautic Owner Rotator Bundle

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -5,6 +5,11 @@
             "package": "dennisameling/helloworld-bundle",
             "minimum_mautic_version": "4.1.0",
             "maximum_mautic_version": null
+        },
+        {
+            "package": "mtcextendee/mautic-owner-rotator-bundle",
+            "minimum_mautic_version": "4.1.0",
+            "maximum_mautic_version": null
         }
     ]
 }


### PR DESCRIPTION
Per https://mautic.atlassian.net/browse/MM-2 this adds the Mautic Owner Rotator Bundle to the Mautic Marketplace.