### PR TITLE
Add bitly to allowslist

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -40,6 +40,12 @@
             "display_name": "Czech Vocative Bundle",
             "minimum_mautic_version": "4.3.0",
             "maximum_mautic_version": null
+        },
+        {
+            "package": "webmecanik/mautic-bitly-bundle",
+            "display_name": "Bitly Bundle",
+            "minimum_mautic_version": "5.0.0",
+            "maximum_mautic_version": null
         }
     ]
 }


### PR DESCRIPTION
Marketplace-allowlist for bundle to use for shortener service include in M5 https://github.com/mautic/mautic/pull/12299
You can test it to add local.php 

`    \Mautic\MarketplaceBundle\Service\Config::MARKETPLACE_ALLOWLIST_URL => 'https://raw.githubusercontent.com/kuzmany/marketplace-allowlist/bilty-bundle/allowlist.json',
`