### PR TITLE
Add AI Email Sections by Bloomidea

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -100,6 +100,12 @@
           "display_name": "Housekeeping by Leuchtfeuer",
           "minimum_mautic_version": "5.0.0",
           "maximum_mautic_version": null
+        },
+        {
+          "package": "bloomidea/mautic-plugin-ai-email-sections",
+          "display_name": "AI Email Sections",
+          "minimum_mautic_version": "7.0.0",
+          "maximum_mautic_version": null
         }
     ]
 }


### PR DESCRIPTION
Requesting inclusion of [`bloomidea/mautic-plugin-ai-email-sections`](https://packagist.org/packages/bloomidea/mautic-plugin-ai-email-sections) in the Marketplace allowlist.

**What it does:** adds an AI assistant panel to the GrapesJS email builder — describe a section in plain text and it generates ready-to-use MJML, styled with the theme's colours and fonts. Generation is validated (strict MJML tag allowlist, automatic retry with validator feedback), and edit mode verifies that AI edits don't drop links, images or personalisation tokens. Works with Anthropic or any OpenAI-compatible endpoint (Ollama, LM Studio, LiteLLM).

- **GitHub:** https://github.com/Bloomidea/mautic-plugin-ai-email-sections (GPL-3.0-or-later, unit + functional tests included)
- **Requires:** `mautic/core-lib: ^7.0`, hence `minimum_mautic_version: 7.0.0`
- **Forum announcement:** https://forum.mautic.org/t/ai-email-sections-generate-mjml-sections-in-the-grapesjs-builder-from-a-text-prompt/38388

We also maintain [`bloomidea/mautic-plugin-resend-nonopeners`](https://packagist.org/packages/bloomidea/mautic-plugin-resend-nonopeners) on Packagist. Happy to make any changes needed for inclusion!